### PR TITLE
Revert "Add the guide release date"

### DIFF
--- a/html/interactive-guides/circuit-breaker/circuit-breaker-guide.html
+++ b/html/interactive-guides/circuit-breaker/circuit-breaker-guide.html
@@ -38,6 +38,5 @@ js:
 - interactive-guides/circuit-breaker/circuit-breaker-callback
 - interactive-guides/circuit-breaker/circuit-breaker-guide
 duration: 25 minutes
-date: 2017-10-03
 permalink: /guides/circuit-breaker
 ---


### PR DESCRIPTION
Reverts OpenLiberty/iguide-circuit-breaker#58

page-date is causing Jekyll build to break. Another Asciidoctor attribute will be needed to replace page-date. Until we have the new attribute, revert the introduction of page-date.