### PR TITLE
Add release date

### DIFF
--- a/html/interactive-guides/circuit-breaker/circuit-breaker-guide.html
+++ b/html/interactive-guides/circuit-breaker/circuit-breaker-guide.html
@@ -38,5 +38,6 @@ js:
 - interactive-guides/circuit-breaker/circuit-breaker-callback
 - interactive-guides/circuit-breaker/circuit-breaker-guide
 duration: 25 minutes
+releasedate: 2017-10-03
 permalink: /guides/circuit-breaker
 ---


### PR DESCRIPTION
Add the release date of the guide so that openliberty.io can sort all the guides by `releasedate` attribute.