### PR TITLE
Feedback items

### DIFF
--- a/html/interactive-guides/circuit-breaker/circuit-breaker-configure-delay.html
+++ b/html/interactive-guides/circuit-breaker/circuit-breaker-configure-delay.html
@@ -20,7 +20,7 @@
         </div>
         <div class="circuitBreakerInfo">
           <div class="circuitBreakerRollingWindowDiv" tabindex='0'>
-            <span class="circuitBreakerRollingWindowDescription">Connection attempts (Most recent to oldest): </span>
+            <span class="circuitBreakerRollingWindowDescription">Connection attempts (Most recent to oldest).  The brackets represent the rolling window: </span>
             <div class="circuitBreakerConnectionAttempts"></div>
           </div>
           <div class="delayCounter">Delay:</div>

--- a/html/interactive-guides/circuit-breaker/circuit-breaker-configure-failure-threshold.html
+++ b/html/interactive-guides/circuit-breaker/circuit-breaker-configure-failure-threshold.html
@@ -20,7 +20,7 @@
         </div>
         <div class="circuitBreakerInfo">
           <div class="circuitBreakerRollingWindowDiv" tabindex='0'>
-            <span class="circuitBreakerRollingWindowDescription">Connection attempts (Most recent to oldest): </span>
+            <span class="circuitBreakerRollingWindowDescription">Connection attempts (Most recent to oldest).  The brackets represent the rolling window: </span>
             <div class="circuitBreakerConnectionAttempts"></div>
           </div>
         </div>

--- a/html/interactive-guides/circuit-breaker/circuit-breaker-configure-success-threshold.html
+++ b/html/interactive-guides/circuit-breaker/circuit-breaker-configure-success-threshold.html
@@ -19,7 +19,7 @@
         </div>
         <div class="circuitBreakerInfo">
           <div class="circuitBreakerRollingWindowDiv" tabindex='0'>
-            <span class="circuitBreakerRollingWindowDescription">Connection attempts (Most recent to oldest): </span>
+            <span class="circuitBreakerRollingWindowDescription">Connection attempts (Most recent to oldest).  The brackets represent the rolling window: </span>
             <div class="circuitBreakerConnectionAttempts"></div>
           </div>
           <div class="delayCounter">Delay:</div>

--- a/html/interactive-guides/circuit-breaker/circuit-breaker-playground.html
+++ b/html/interactive-guides/circuit-breaker/circuit-breaker-playground.html
@@ -19,7 +19,7 @@
         </div>
         <div class="circuitBreakerInfo">          
           <div class="circuitBreakerRollingWindowDiv" tabindex='0'>
-            <span class="circuitBreakerRollingWindowDescription">Connection attempts (Most recent to oldest): </span>
+            <span class="circuitBreakerRollingWindowDescription">Connection attempts (Most recent to oldest).  The brackets represent the rolling window: </span>
             <div class="circuitBreakerConnectionAttempts"></div>
           </div>
           <div class="delayCounter">Delay:</div>

--- a/js/interactive-guides/circuit-breaker/circuit-breaker-callback.js
+++ b/js/interactive-guides/circuit-breaker/circuit-breaker-callback.js
@@ -91,8 +91,9 @@ var circuitBreakerCallBack = (function() {
                                 contentManager.updateWithNewInstructionNoMarkComplete(stepName);
                                 //contentManager.updateWithNewInstruction(stepName);
                                 contentManager.setPodContentWithRightSlide(webBrowser.getStepName(),
-                                    "<p class='maxspace'>The request is routed to the Check Balance microservice but the microservice is down. Since the circuit breaker has a " +
-                                    "policy to open the circuit after 1 failure (2 requestVolumeThreshold x 0.5 failureRatio) occurs in a rolling window of 2 requests, the circuit remains <b>closed</b>.</p> " +
+                                    "<p class='maxspace'>The request is routed to the Check Balance microservice but the microservice is down. The circuit breaker policy " +
+                                    "opens the circuit after 1 failure, which comes from multiplying the requestVolumeThreshold (2) by the failureRatio (0.5). " +
+                                    "However, the circuit remains <b>closed</b> because the number of requests is less than the size of the rolling window (2). </p>" +
                                     "<img src='/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/images/closed-fail.svg' alt='Check Balance microservice resulting in open circuit' class='picInPod'>",
                                     1
                                 );

--- a/json-guides/circuit-breaker.json
+++ b/json-guides/circuit-breaker.json
@@ -74,7 +74,7 @@
             "name": "AddLibertyMPFaultTolerance",
             "title": "Enabling MicroProfile Fault Tolerance",
             "description": [
-                "Microprofile fault tolerance is a way for microservices to handle the unavailability of a service by using different policies to guide the execution and result of some logic.  The MicroProfile Fault Tolerance 1.0 feature provides an environment to support resilient microservices through patterns that include circuit breakers and fallbacks.  Enable the MicroProfile Fault Tolerance 1.0 feature in the server.xml of the Liberty server where the Check Balance microservice runs."
+                "Microprofile fault tolerance is a way for microservices to handle the unavailability of a service by using different policies to guide the execution and result of some logic.  The MicroProfile Fault Tolerance 1.0 feature provides an environment to support resilient microservices through patterns that include circuit breakers and fallbacks.  Enable the MicroProfile Fault Tolerance 1.0 feature in the <code>server.xml</code> of the Liberty server where the Check Balance microservice runs."
             ],
             "instruction": [
               "Add the following element declaration inside the featureManager element to the <code>server.xml</code> file, or click <action title='Enable MicroProfile Fault Tolerance' onclick=\"circuitBreakerCallBack.addMicroProfileFaultToleranceFeatureButton(event)\"><b>&lt;feature>mpFaultTolerance-1.0&lt;/feature&gt;</b></action>. Then, click <action title='Save' onclick=\"circuitBreakerCallBack.saveServerXMLButton(event)\"><b>Save</b></action> on the editor menu pane."
@@ -160,7 +160,7 @@
           "description":
           [
             "The CircuitBreaker policy opens the circuit when the failure threshold is met. When the circuit is open, calls to the failing service will fail immediately. The policy determines the failure threshold by monitoring a specified number of the most recent consecutive requests made to the service, also known as a <b>rolling window</b>. You can modify the failure threshold by using these two parameters:<br/>",
-            "<ul><li><b>requestVolumeThreshold:</b> The minimum number of requests that must be made before determining if the circuit should trip.  It indicates the size of the rolling window. The default is <code>20</code> requests.",
+            "<ul><li><b>requestVolumeThreshold:</b> The minimum number of requests that must be made before determining if the circuit should trip.  This also specifies the size of the rolling window. The default is <code>20</code> requests.",
             "<li><b>failureRatio:</b> The minimum failure ratio in the rolling window that triggers the circuit breaker. The default ratio is <code>0.5</code>.",
             "</ul>",
             "The requestVolumeThreshold parameter is multiplied by the failureRatio parameter to determine the minimum number of failure requests within a rolling window to trip the circuit. The total requests must be at least the size of the rolling window before the circuit breaker can trigger.",
@@ -187,7 +187,7 @@
           "TOCIndent": 1,
           "description": [
             "You can configure the number of milliseconds the circuit remains open with the delay parameter. During the period that the circuit remains open, all requests to the main service are blocked and fail immediately. At the end of this period, the circuit changes to the half-open state. This half-open state is a temporary state where further requests to the main microservice are allowed through and checked for success or failure.",
-            "<br/><ul><li><b>delay:</b> The delay in milliseconds after the circuit opens until checking the availability of the main service.  The default is <code>5000 ms</code>.</li></ul>"
+            "<br/><ul><li><b>delay:</b> The delay in milliseconds after the circuit opens until checking the availability of the main service.  The default is <code>5000</code> ms.</li></ul>"
           ],
           "instruction": [
               "Change the <code>@CircuitBreaker</code> annotation on lines 7 and 8 to the following code, or click <br><action title='Circuit breaker annotation with delay parameter' onclick=\"circuitBreakerCallBack.addCircuitBreakerAnnotationButton(event, 'ConfigureDelayParams')\"><b>@CircuitBreaker\n(requestVolumeThreshold=2, failureRatio=0.5, delay=5000)</b></action>.<br> Then, click <action title='Run' onclick=\"circuitBreakerCallBack.saveButtonEditorButton(event, 'ConfigureDelayParams')\"><b>Run</b></action>.",
@@ -303,10 +303,10 @@
               "Now that you learned about circuit breakers and fallbacks, you can explore the parameters in the <code>@CircuitBreaker</code> annotation and see the circuit in action.",
               "<br>You learned about the following parameters:",
               "<ul>",
-              "<li><b>requestVolumeThreshold</b>: The size of the rolling window that is used to determine the failure threshold. The default is <code>20</code>.",
-              "<li><b>failureRatio</b>: The minimum failure ratio in the rolling window to trigger the circuit breaker. The default is <code>0.5</code>.",
-              "<li><b>delay</b>: The delay in milliseconds to transition to a half-open state after the circuit opens. The default is <code>5000 ms</code>.",
-              "<li><b>successThreshold</b>: The number of consecutive successful invocations of the service that is required before the circuit closes. The default is <code>1</code>.",
+              "<li><b>requestVolumeThreshold</b>: The minimum number of requests that must be made before determining if the circuit should trip. This also specifies the size of the rolling window. The default is <code>20</code> requests.",
+              "<li><b>failureRatio</b>: The minimum failure ratio in the rolling window to trigger the circuit breaker. The default ratio is <code>0.5</code>.",
+              "<li><b>delay</b>: The delay in milliseconds to transition to a half-open state after the circuit opens. The default is <code>5000</code> ms.",
+              "<li><b>successThreshold</b>: The number of consecutive successful invocations of the service that is required before the circuit closes. The default is <code>1</code> request.",
               "</ul>",
               "You can simulate successful or failed requests to the microservice to see how the circuit state changes.",
               "<br><instruction style='display:inline-block' tabindex='0'><b>Modify</b> the parameters for the <code>@CircuitBreaker</code> annotation in the following file. Repeat the process as many times as you want. <br><br>Click <b>Success</b> for successful requests or <b>Failure</b> for failed requests and observe the simulation.</instruction>"

--- a/json-guides/circuit-breaker.json
+++ b/json-guides/circuit-breaker.json
@@ -74,7 +74,7 @@
             "name": "AddLibertyMPFaultTolerance",
             "title": "Enabling MicroProfile Fault Tolerance",
             "description": [
-                "Begin by enabling the MicroProfile Fault Tolerance 1.0 feature in your <code>server.xml</code> file.  This feature is required and provides an environment to support resilient microservices through patterns that include circuit breakers and fallbacks."
+                "Microprofile fault tolerance is a way for microservices to handle the unavailability of a service by using different policies to guide the execution and result of some logic.  The MicroProfile Fault Tolerance 1.0 feature provides an environment to support resilient microservices through patterns that include circuit breakers and fallbacks.  Enable the MicroProfile Fault Tolerance 1.0 feature in the server.xml of the Liberty server where the Check Balance microservice runs."
             ],
             "instruction": [
               "Add the following element declaration inside the featureManager element to the <code>server.xml</code> file, or click <action title='Enable MicroProfile Fault Tolerance' onclick=\"circuitBreakerCallBack.addMicroProfileFaultToleranceFeatureButton(event)\"><b>&lt;feature>mpFaultTolerance-1.0&lt;/feature&gt;</b></action>. Then, click <action title='Save' onclick=\"circuitBreakerCallBack.saveServerXMLButton(event)\"><b>Save</b></action> on the editor menu pane."
@@ -111,7 +111,7 @@
             "name": "AfterAddCircuitBreakerAnnotation",
             "title": "Adding the @CircuitBreaker annotation",
             "description": [
-                "After you modify your <code>server.xml</code> file to <a href='#enabling-microprofile-fault-tolerance'>include the fault tolerance feature</a>, add a default CircuitBreaker policy to the Check Balance microservice."
+                "After you modify your <code>server.xml</code> file to <a href='#enabling-microprofile-fault-tolerance'>include the fault tolerance feature</a>, add the default CircuitBreaker policy to the Check Balance microservice to prevent repeated request failures from overloading the system."
             ],
             "instruction": [
               "Add the <code>@CircuitBreaker</code> annotation on line 6, before the checkBalance method, or click <action title='@CircuitBreaker annotation' onclick=\"circuitBreakerCallBack.addCircuitBreakerAnnotationButton(event, 'AfterAddCircuitBreakerAnnotation')\"><b>@CircuitBreaker()</b></action>. Then, click <action title='Save' onclick=\"circuitBreakerCallBack.saveButtonEditorButton(event, 'AfterAddCircuitBreakerAnnotation')\"><b>Save</b></action> on the editor menu pane."
@@ -159,11 +159,12 @@
           "browserContent": "/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/check-balance-fail-with-open-circuit.html",
           "description":
           [
-            "The CircuitBreaker policy opens the circuit when sufficient calls to the microservice fail. The policy determines the failure threshold by looking at the latest requests to the service, also known as a <b>rolling window</b>. You can modify this failure threshold by using these two parameters:<br/>",
-            "<ul><li><b>requestVolumeThreshold:</b> The size of the rolling window that is used to determine the failure threshold. The default is <code>20</code>.",
-            "<li><b>failureRatio:</b> The minimum failure ratio in the rolling window that triggers the circuit breaker. The default is <code>0.5</code>.",
+            "The CircuitBreaker policy opens the circuit when the failure threshold is met. When the circuit is open, calls to the failing service will fail immediately. The policy determines the failure threshold by monitoring a specified number of the most recent consecutive requests made to the service, also known as a <b>rolling window</b>. You can modify the failure threshold by using these two parameters:<br/>",
+            "<ul><li><b>requestVolumeThreshold:</b> The minimum number of requests that must be made before determining if the circuit should trip.  It indicates the size of the rolling window. The default is <code>20</code> requests.",
+            "<li><b>failureRatio:</b> The minimum failure ratio in the rolling window that triggers the circuit breaker. The default ratio is <code>0.5</code>.",
             "</ul>",
-            "The failureRatio parameter is used with the requestVolumeThreshold parameter to determine when the circuit trips. The total requests must be equal to or greater than the rolling window size before the circuit breaker can trigger.",
+            "The requestVolumeThreshold parameter is multiplied by the failureRatio parameter to determine the minimum number of failure requests within a rolling window to trip the circuit. The total requests must be at least the size of the rolling window before the circuit breaker can trigger.",
+            "",
             "For example, when the requestVolumeThreshold parameter is set to a value of <code>20</code> and the failureRatio parameter is set to a value of <code>0.5</code>, the circuit breaker requires a minimum of 20 total requests with at least 10 failures in the latest 20 requests to open the circuit."
           ],
           "instruction": [
@@ -185,8 +186,8 @@
           "title": "Configuring a delay",
           "TOCIndent": 1,
           "description": [
-            "By default, the circuit remains open for <code>5000 ms</code>. You can configure the number of milliseconds with the delay parameter. During the period that the circuit remains open, all requests to the main service are blocked and fail immediately. At the end of this period, the circuit changes to the half-open state. This half-open state is a temporary state where further requests to the main microservice are allowed through and checked for success or failure.",
-            "<br/><ul><li><b>delay:</b> The delay in milliseconds after the circuit opens until checking the availability of the main service.</li></ul>"
+            "You can configure the number of milliseconds the circuit remains open with the delay parameter. During the period that the circuit remains open, all requests to the main service are blocked and fail immediately. At the end of this period, the circuit changes to the half-open state. This half-open state is a temporary state where further requests to the main microservice are allowed through and checked for success or failure.",
+            "<br/><ul><li><b>delay:</b> The delay in milliseconds after the circuit opens until checking the availability of the main service.  The default is <code>5000 ms</code>.</li></ul>"
           ],
           "instruction": [
               "Change the <code>@CircuitBreaker</code> annotation on lines 7 and 8 to the following code, or click <br><action title='Circuit breaker annotation with delay parameter' onclick=\"circuitBreakerCallBack.addCircuitBreakerAnnotationButton(event, 'ConfigureDelayParams')\"><b>@CircuitBreaker\n(requestVolumeThreshold=2, failureRatio=0.5, delay=5000)</b></action>.<br> Then, click <action title='Run' onclick=\"circuitBreakerCallBack.saveButtonEditorButton(event, 'ConfigureDelayParams')\"><b>Run</b></action>.",
@@ -206,8 +207,7 @@
           "TOCIndent": 1,
           "description": [
               "When the circuit is half-open, requests to the microservice are allowed through. However, if a request fails while the circuit is half-open, it immediately returns and the circuit reverts to an open state. Otherwise, if a specified number of consecutive requests succeed while the circuit is in a half-open state, the microservice is deemed healthy and the circuit closes.",
-              "The default number of consecutive successes that are needed is <code>1</code>, and can be adjusted with the successThreshold parameter.",
-              "<br/><ul><li><b>successThreshold:</b> The number of consecutive successful invocations of the service required before closing the circuit.</ul>"
+              "<br/><ul><li><b>successThreshold:</b> The number of consecutive successful invocations of the service required before closing the circuit.  The default is <code>1</code> request.</ul>"
           ],
           "instruction": [
               "Change the <code>@CircuitBreaker</code> annotation on lines 7 - 9 to the following code, or click<action title='Circuit breaker annotation with success threshold parameter' aria-label='Circuit breaker annotation with success threshold parameter' onclick=\"circuitBreakerCallBack.addCircuitBreakerAnnotationButton(event, 'ConfigureSuccessThresholdParams')\"><b>@CircuitBreaker\n(requestVolumeThreshold=2, failureRatio=0.5, delay=5000, successThreshold=2)</b></action>.<br> Then, click <action title='Run' aria-label='Run' onclick=\"circuitBreakerCallBack.saveButtonEditorButton(event, 'ConfigureSuccessThresholdParams')\"><b>Run</b></action>.",


### PR DESCRIPTION
Based on the feedback in issue #74, the following items were implemented.

- [x] 'Enabling MicroProfile Fault Tolerance step - reiterate why we are adding in fault tolerance to our application and indicate that this is how to add the feature in WAS Liberty.
**ID**:  Review the opening paragraph

- [x] 'Adding the @CircuitBreaker annotation' step - In the opening paragraph, add more of a blurb on why we are adding the @CB annotation similar to what we have in the From the 'What you'll learn' step where we indicate 'you'll include the @CircuitBreaker annotation so that your microservice fails immediately to prevent repeated calls that are likely to fail. '
**ID**: Review the opening paragraph 

- [x] In 'Configuring the failure threshold' step, work on clarifying the definition for **rolling window**, **requestVolumeTheshold** and **failureRatio**.  Emphasize how these values are **multiplied** to determine the failure threshold. 
**ID**: Review all the text up to the first green instruction block.  It was all modified.

- [x] In 'Configuring the failure threshold' step, after selecting the Refresh button the first time, the description that slides in should be reworded to explain the math portion better. Have this description read more clearly.
**ID:** Follow the 1st instruction in the green instruction block and update the @CircuitBreaker annotation and select run.  A 2nd green instruction block will appear.  Select Refresh.  The text that was updated was the text that appears to the right of the mini-browser window after it is done spinning.   Please review that.

- [x] In 'Configuring the failure threshold' step, get rid of the trailing space in 'The failureRatio parameter...' paragraph so that the sentence 'For example,...' doesn't look like its a new paragraph.  Specifically:
'...rolling window size before the circuit breaker can trigger. \<REMOVE SPACE HERE\>For example, when the requestVolumeThreshold parameter is ...'

- [x] In 'Configuring the  failure threshold' and the 'Playground' steps, we need to indicate that the brackets '[' ']' mean rolling window.  
Updates were made to 4 html files where the rolling window in a playground was displayed.  The statement is shown in the following picture:
![brackets](https://user-images.githubusercontent.com/29490139/35757028-1215a23e-0833-11e8-8ed9-8644301206aa.PNG)

    **ID:** Please review the paragraph in the picture above beginning with 'Connection attempts...', just below the Reset button.

- [x] In 'Configuring a delay' step, rework so the default is included with the definition.
**ID:** Review the definition for **delay**.  It should now include the default value for this parameter.

- [x] In 'Configuring the success threshold' step, rework so the default is included with the definition thereby removing the blank line above the paragraph beginning with 'The default number of consecutive successes...'.
**ID:** Review the definition for **successThreshold**.  It should now include the default value for this parameter.

- [x] In 'Interactive circuit breaker playground' step, update definitions to include the specifications for each default value (ie. 'requests', 'ratio', 'ms', and 'request').
