### PR TITLE
Do not process delay on Failure Threshold step

### DIFF
--- a/js/interactive-guides/circuit-breaker/circuit-breaker.js
+++ b/js/interactive-guides/circuit-breaker/circuit-breaker.js
@@ -254,6 +254,13 @@ var circuitBreaker = function(){
         this.state = circuitState.open;
         this.updateDiagramAndCounters();
 
+        if (me.stepName === "ConfigureFailureThresholdParams") {
+          return; // No need to go through delay since we haven't exposed that
+                  // parameter yet at this step.  Otherwise, we go to a 
+                  // half-open state at the end of the delay and visually the 
+                  // user sees the rolling window "mysteriously" disappear.
+        }
+
         var secondsLeft = this.delay;
         var delayCounter = this.root.find('.delayCounter');
 


### PR DESCRIPTION
 In our playgrounds, when the circuit goes to a half-open state the rolling window is removed from the requests (boxes).  At the 'Configuring the failure threshold' step, the user has not yet learned about the 'delay' parameter or the half-open state.  Therefore, we should prevent the playground from processing the default delay on this step since it is not yet necessary.   Otherwise, when we let the default delay be processed, the brackets representing the rolling window are "mysteriously" removed in 5 seconds and may cause the user some confusion.