### PR TITLE
Assign the multipane layout to the Circuit Breaker guide

### DIFF
--- a/html/interactive-guides/circuit-breaker/circuit-breaker-guide.html
+++ b/html/interactive-guides/circuit-breaker/circuit-breaker-guide.html
@@ -1,5 +1,5 @@
 ---
-layout: interactive-guide
+layout: iguide-multipane
 title: "Preventing repeated failed calls to microservices"
 description: Learn how to create a fault-tolerant microservice using MicroProfile's CircuitBreaker and Fallback policies.
 tags: ['Interactive', 'MicroProfile', 'microservices', 'Circuit Breaker', '@CircuitBreaker', '@Fallback', 'Fault Tolerance']
@@ -8,7 +8,6 @@ css:
 - interactive-guides/step-content
 - interactive-guides/editor
 - interactive-guides/tabbed-editor
-- interactive-guides/table-of-contents
 - interactive-guides/file-browser
 - interactive-guides/web-browser
 - interactive-guides/pod

--- a/js/interactive-guides/circuit-breaker/circuit-breaker-guide.js
+++ b/js/interactive-guides/circuit-breaker/circuit-breaker-guide.js
@@ -14,6 +14,5 @@ $(document).ready(function() {
   
     jsonGuide.getAGuide(iguideJsonName).done(function() {
       blueprint.create(iguideContextRoot);
-      $(ID.toc_guide_title).hide();
     });
   });


### PR DESCRIPTION
Assign the multipane layout to the Circuit Breaker guide.  Also remove the Guide title from above the TOC since this is not part of the new multipane layout design.