### PR TITLE
Adding end of guide info and links based on new design 

### DIFF
--- a/html/interactive-guides/circuit-breaker/circuit-breaker-guide.html
+++ b/html/interactive-guides/circuit-breaker/circuit-breaker-guide.html
@@ -3,6 +3,7 @@ layout: iguide-multipane
 title: "Preventing repeated failed calls to microservices"
 description: Learn how to create a fault-tolerant microservice using MicroProfile's CircuitBreaker and Fallback policies.
 tags: ['Interactive', 'MicroProfile', 'microservices', 'Circuit Breaker', '@CircuitBreaker', '@Fallback', 'Fault Tolerance']
+categories: MicroProfile
 css:
 - interactive-guides/main
 - interactive-guides/step-content

--- a/json-guides/circuit-breaker.json
+++ b/json-guides/circuit-breaker.json
@@ -392,8 +392,15 @@
         {
             "name": "WhatNext",
             "title": "Great work!  You're done!",
-            "description": ["You learned how to use a circuit breaker and provide a fallback to make your microservice fault tolerant.",
-                            "<p> <a href='https://github.com/OpenLiberty/iguide-circuit-breaker/tree/master/finish/sampleapp_circuitbreaker.zip' >Download the sample circuit breaker application on github</a>.</p>"
+            "description": ["You learned how to use a circuit breaker and provide a fallback to make your microservice fault tolerant."
+                           ]
+        },
+        {
+            "name": "RelatedLinks",
+            "title": "Related links",
+            "description": ["Dive into the <b>MicroProfile config</b>.",
+                            "<p> <a target='_blank' rel='noopener noreferrer' href='http://microprofile.io/' >See MicroProfile Config specs.</a></p>",
+                            "<p> <a target='_blank' rel='noopener noreferrer' href='https://openliberty.io/docs/ref/microprofile/' >Another link to MicroProfile specs (openliberty.io).</a></p>"
                            ]
         }
     ]

--- a/json-guides/circuit-breaker.json
+++ b/json-guides/circuit-breaker.json
@@ -398,9 +398,9 @@
         {
             "name": "RelatedLinks",
             "title": "Related links",
-            "description": ["Dive into the <b>MicroProfile config</b>.",
-                            "<p> <a target='_blank' rel='noopener noreferrer' href='http://microprofile.io/' >See MicroProfile Config specs.</a></p>",
-                            "<p> <a target='_blank' rel='noopener noreferrer' href='https://openliberty.io/docs/ref/microprofile/' >Another link to MicroProfile specs (openliberty.io).</a></p>"
+            "description": ["Learn more about <b>MicroProfile</b>.",
+                            "<p> <a target='_blank' rel='noopener noreferrer' href='http://microprofile.io/' >See the MicroProfile specs.</a></p>",
+                            "<p> <a target='_blank' rel='noopener noreferrer' href='https://openliberty.io/docs/ref/microprofile/' >View MicroProfile API.</a></p>"
                            ]
         }
     ]


### PR DESCRIPTION
I used these redlines: https://ibm.ent.box.com/file/292168237908
Changes made:
- _circuit-breaker-guide.html_: Added 'categories: MicroProfile' 
- _circuit-breaker.json_: Added 'RelatedLinks' section and removed sample application link from the 'WhatNext' section since it will be moved to the 'Where to next?' section on the right 
** **note:** in the redlines don't include the "download sample app" link since it was based on static guides 