### PR TITLE
First pass at getting the guide steps to fit in multipane

### DIFF
--- a/css/interactive-guides/circuit-breaker/checkBalance.css
+++ b/css/interactive-guides/circuit-breaker/checkBalance.css
@@ -30,8 +30,8 @@ html, body {
 
 .flexWarningContainer > div {
   text-align: center;
-  line-height: 26px;
-  font-size: 16px;
+  line-height: 24px;
+  font-size: 14px;
   align-self: center;
   color: #272727;
   letter-spacing: 0;
@@ -43,17 +43,17 @@ html, body {
 }
 
 .checkBalanceContainer > p {
-  font-size: 16px;
+  font-size: 14px;
   color: #272727;
   letter-spacing: 0;
-  line-height: 26px;
+  line-height: 24px;
   text-align: left;
-  margin-bottom: 14px;
+  margin-bottom: 12px;
 }
 
 .checkBalanceContainer > p.balance {
   font-size: 28px;
-  margin-top: 14px;
+  margin-top: 12px;
   margin-bottom: 31px;
 }
 

--- a/css/interactive-guides/circuit-breaker/circuit-breaker.scss
+++ b/css/interactive-guides/circuit-breaker/circuit-breaker.scss
@@ -97,15 +97,50 @@
 }
 .bankScenarioImg > img {
   width: 45%;
-  min-width: 200px;
-  max-width: 250px;
+  min-width: 150px;
+  max-width: 200px;
+}
+
+.cbCenterPod {
+  background: rgba(255,255,255,0.75);
 }
 
 .picInPod {
-  max-width: 55%;
-  margin-left: auto;
-  margin-right: auto;
   display: block;
+
+  @media (max-width: 1169px) {
+    width: 55%;
+    max-width: 150px;
+  }
+
+  @media (min-width: 1170px) {
+    margin: 5px;
+    max-width: 110px;
+  }
+
+}
+
+.flexWithPic {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+
+  @media (max-width: 1170px) {
+    flex-direction: column;
+  }
+}
+
+.flexWithPicParagraph {
+  flex-grow: 1;
+  flex-basis: 10%;
+  margin: 0 20px 10px 10px;
+}
+
+.centerPicInPod {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
 }
 
 @media only screen and (min-width : 425px){
@@ -282,6 +317,9 @@ span.round-tab i{
 
 #guide_content p.maxspace {
   margin-top: 0;
+}
+#code_column .flexWithPic p {
+  margin: 5px 20px 5px 5px;
 }
 
 .backgroundConcepts img {

--- a/js/interactive-guides/circuit-breaker/circuit-breaker-callback.js
+++ b/js/interactive-guides/circuit-breaker/circuit-breaker-callback.js
@@ -27,18 +27,21 @@ var circuitBreakerCallBack = (function() {
 
                 var stepName = this.getStepName();
                 switch (stepName) {
-                    case 'CheckBalance':
+                    case 'BankScenario':
                         __refreshWebBrowserContent(webBrowser, "/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/check-balance-fail.html");
                         contentManager.markCurrentInstructionComplete(stepName);
                         isRefreshing = true;
                         setTimeout(function () {
                             contentManager.setPodContentWithRightSlide(stepName,
+                                "<div class='flexWithPic'>" +
                                 "<p class='maxspace'>Oh no! The Check Balance microservice is down!  As more requests come into the service, the users notice that their check balance requests are taking much longer and seem to hang.   " +
                                 "The users repeatedly refresh the page, stacking up the requests to the Check Balance microservice even further. " +
                                 "Eventually, the web application is so busy servicing the failed requests that it comes to a crawl, " +
                                 "even for those not using the Check Balance microservice." +
                                 "</p>" +
-                                "<img src='/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/images/no-circuit-breaker-service-fail.svg' alt='Microservice is down' class='picInPod'>"
+                                "<img src='/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/images/no-circuit-breaker-service-fail.svg' alt='Microservice is down' class='picInPod'>" +
+                                "</div>",
+                                0
                             );
                             isRefreshing = false;
                         }, 5000);
@@ -49,12 +52,14 @@ var circuitBreakerCallBack = (function() {
                              __refreshWebBrowserContent(webBrowser, "/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/check-balance-fail-with-open-circuit.html");
                             contentManager.markCurrentInstructionComplete(stepName);
                             contentManager.setPodContentWithRightSlide(stepName,
+                                "<div class='flexWithPic'>" +
                                 "<p class='maxspace'>Assuming the circuit is in an <b>open</b> state, the request to the Check Balance microservice fails immediately.  You are instantly notified of the problem and no longer must wait for the time-out period to occur to receive the notification.</p>" +
                                 "<p style='margin-top: 10px;'>The circuit remains in an open state for <code>5000 ms</code> before switching to a <b>half-open</b> state.</p> " +
                                 "<div style='font-size: 16px;'><b>Delay:&nbsp;&nbsp;</b><span class='delayCountdown'>5000 ms</span></div>" +
                                 "<div style='font-size: 16px; margin-bottom: 20px;'><b>Circuit State:&nbsp;&nbsp;</b><span class='delayState'> Open</span></div>" +
-                            "<div class='delayCountdownImg'><img src='/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/images/open.svg' alt='Check Balance microservice in open circuit' class='picInPod'></div>",
-                                1
+                                "<div class='delayCountdownImg'><img src='/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/images/open.svg' alt='Check Balance microservice in open circuit' class='picInPod'></div>" +
+                                "</div>",
+                                0
                             );
                             var secondsLeft = 9000;
                             var $delayCountdown = $('.delayCountdown');
@@ -69,17 +74,11 @@ var circuitBreakerCallBack = (function() {
 
                                     clearInterval(delayCountdownInterval);   // Stop interval
                                     // Slide in new pic
-                                    //                                var newPic = "<div class='pod-animation-slide-from-right'><b>blah</b></div>";
-                                var newPic = "<div class='pod-animation-slide-from-right'><img src='/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/images/halfopen.svg' alt='Check Balance microservice in half-open circuit' class='picInPod'></div>";
+                                    var newPic = "<div class='pod-animation-slide-from-right'><img src='/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/images/halfopen.svg' alt='Check Balance microservice in half-open circuit' class='picInPod'></div>";
                                     $('.delayCountdownImg').html(newPic);
                                     isRefreshing = false;
                                 }
                             }, 100);
-                            var stepPod = contentManager.getPod("ConfigureDelayParams", 0).accessPodContent();
-                            var breadcrumbElement = stepPod.find('.delaySteps > .stepProgression > .tabContainer-tabs > .nav-tabs');
-                            breadcrumbElement.find('a[href="#delay-playground"]').parent('li').addClass('enabled');
-                            breadcrumbElement.find('a[href="#delay-playground"]').attr('aria-disabled', 'false');
-                            stepPod.find("#delay-action .nextTabButton").css("display", "block");
                         break;
                     case 'ConfigureFailureThresholdParams':
                         var currentStepIndex = contentManager.getCurrentInstructionIndex(stepName);
@@ -90,36 +89,34 @@ var circuitBreakerCallBack = (function() {
                            isRefreshing = true;
                            setTimeout(function () {
                                 contentManager.setPodContentWithRightSlide(webBrowser.getStepName(),
+                                    "<div class='flexWithPic'>" +
                                     "<p class='maxspace'>The request is routed to the Check Balance microservice, but the microservice is down. The circuit breaker policy " +
                                     "opens the circuit after 1 failure, which comes from multiplying the requestVolumeThreshold (2) by the failureRatio (0.5). " +
                                     "However, the circuit remains <b>closed</b> because the number of requests is fewer than the size of the rolling window (2). </p>" +
-                                    "<img src='/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/images/closed-fail.svg' alt='Check Balance microservice resulting in open circuit' class='picInPod'>",
-                                    1
+                                    "<img src='/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/images/closed-fail.svg' alt='Check Balance microservice resulting in open circuit' class='picInPod'>" +
+                                    "</div>",
+                                    0
                                 );
                                 webBrowser.enableRefreshButton(true);
                                 isRefreshing = false;
                             }, 5000);
                         } if (currentStepIndex >= 2 || currentStepIndex === -1) {
-                            contentManager.setPodContentWithRightSlide(webBrowser.getStepName(), "", 1);
+                            contentManager.setPodContentWithRightSlide(webBrowser.getStepName(), "", 0);
                             __refreshWebBrowserContent(webBrowser, "/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/check-balance-fail.html");
                             contentManager.markCurrentInstructionComplete(stepName);
                             isRefreshing = true;
                             setTimeout(function () {
                                 contentManager.setPodContentWithRightSlide(stepName,
+                                    "<div class='flexWithPic'>" +
                                     "<p class='maxspace'>The request is routed to the Check Balance microservice, but the microservice is still down. Since this failure is the second one " +
                                     "in a rolling window of 2 requests, the circuit is now <b>opened</b>.  " +
                                     "The next request to the Check Balance microservice will immediately fail.</p>" +
-                                    "<img src='/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/images/open.svg' alt='Check Balance microservice resulting in open circuit' class='picInPod'>",
-                                    1
+                                    "<img src='/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/images/open.svg' alt='Check Balance microservice resulting in open circuit' class='picInPod'>" +
+                                    "</div>",
+                                    0
                                 );
-                                stepPod.find(".nextTabButton").css("display", "block");
                                 isRefreshing = false;
                             }, 5000);
-                            var stepPod = contentManager.getPod("ConfigureFailureThresholdParams", 0).accessPodContent();
-                            var breadcrumbElement = stepPod.find('.failureThresholdSteps > .stepProgression > .tabContainer-tabs > .nav-tabs');
-                            breadcrumbElement.find('a[href="#failureThreshold-playground"]').parent('li').addClass('enabled');
-                            breadcrumbElement.find('a[href="#failureThreshold-playground"]').attr('aria-disabled', 'false');
-                            stepPod.find(".nextTabButton").css("display", "none");
                         }
                         break;
                 }
@@ -197,14 +194,7 @@ var circuitBreakerCallBack = (function() {
             if (__checkCircuitBreakerAnnotationInContent(content, paramsToCheck, stepName) === true) {
                 contentManager.markCurrentInstructionComplete(stepName);
                 contentManager.setPodContentWithRightSlide(stepName,
-                  /*
-                    "<p>A CircuitBreaker policy is added to the Check Balance microservice, which is to open the circuit " +
-                    "when 1 (2 requestVolumeThreshold x 0.50 failureRatio) failure occurs among the rolling window of 2 " +
-                    " consecutive invocations. The circuit will stay open for 2000ms. Any call made to the service will fail " +
-                    " immediately when the circuit is opened. After the delay, the circuit transitions to half-open." +
-                    " After 2 consecutive successful invocations, the circuit will be back to close again.<br/>" +
-                  */
-                  "<img src='/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/images/with-circuit-breaker.svg' alt='Check Balance microservice with circuit breaker' class='picInPod'>"
+                  "<div class='centerPicInPod'><img src='/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/images/with-circuit-breaker.svg' alt='Check Balance microservice with circuit breaker' class='picInPod'></div>"
                 );
             } else {
                 // display error
@@ -215,7 +205,7 @@ var circuitBreakerCallBack = (function() {
     };
 
     var __listenToEditorForAnnotationParamChange = function(editor) {
-        var __hideEditor = function() {
+        var __validateConfigureParamsInEditor = function() {
             var updateSuccess = false;
             var stepName = editor.getStepName();
             var content = contentManager.getTabbedEditorContents(stepName, bankServiceFileName);
@@ -253,38 +243,17 @@ var circuitBreakerCallBack = (function() {
             }
 
             if (updateSuccess) {
-                if (stepName === "ConfigureFailureThresholdParams") {
-                    var stepPod = contentManager.getPod("ConfigureFailureThresholdParams", 0).accessPodContent();
-                    var breadcrumbElement = stepPod.find('.failureThresholdSteps > .stepProgression > .tabContainer-tabs > .nav-tabs');
-                    breadcrumbElement.find('a[href="#failureThreshold-edit"]').parent('li').addClass('enabled');
-                    breadcrumbElement.find('a[href="#failureThreshold-action"]').parent('li').addClass('enabled active');
-                    breadcrumbElement.find('a[href="#failureThreshold-action"]').attr('aria-disabled','false');
-                    breadcrumbElement.find('a[href="#failureThreshold-action"]').click();
-                } else if (stepName === "ConfigureDelayParams") {
-                    var stepPod = contentManager.getPod("ConfigureDelayParams", 0).accessPodContent();
-                    var breadcrumbElement = stepPod.find('.delaySteps > .stepProgression > .tabContainer-tabs > .nav-tabs');
-                    breadcrumbElement.find('a[href="#delay-edit"]').parent('li').addClass('enabled');
-                    breadcrumbElement.find('a[href="#delay-action"]').parent('li').addClass('enabled active');
-                    breadcrumbElement.find('a[href="#delay-action"]').attr('aria-disabled','false');
-                    breadcrumbElement.find('a[href="#delay-action"]').click();
-                } else if (stepName === "ConfigureSuccessThresholdParams") {
-                    var stepPod = contentManager.getPod("ConfigureSuccessThresholdParams", 0).accessPodContent();
-                    var breadcrumbElement = stepPod.find('.successThresholdSteps > .stepProgression > .tabContainer-tabs > .nav-tabs');
-                    breadcrumbElement.find('a[href="#successThreshold-edit"]').parent('li').addClass('enabled');
-                    breadcrumbElement.find('a[href="#successThreshold-action"]').parent('li').addClass('enabled active');
-                    breadcrumbElement.find('a[href="#successThreshold-action"]').attr('aria-disabled','false');
-                    breadcrumbElement.find('a[href="#successThreshold-action"]').click();
-                }
+                // Put the browser into focus.
+                var stepBrowser = contentManager.getBrowser(stepName);
+
                 contentManager.markCurrentInstructionComplete(stepName);
                 var currentStepIndex = contentManager.getCurrentInstructionIndex(stepName);
-
             } else {
                 // display error
-
                 editor.createErrorLinkForCallBack(true, __correctEditorError);
             }
         };
-        editor.addSaveListener(__hideEditor);
+        editor.addSaveListener(__validateConfigureParamsInEditor);
     };
 
     var __listenToEditorForFallbackAnnotation = function(editor) {
@@ -723,25 +692,13 @@ var circuitBreakerCallBack = (function() {
     //When the 'Configure it' button is clicked, the playgroud for the corresponding
     //configure step should appear in the result section of the "code" column.
     var __configureIt = function(stepName) {
-      var stepPod;
+      var stepPod = contentManager.getPod(stepName, 0);
       var breadcrumbElement;
       var activeStep;
 
       if (stepName === "ConfigureFailureThresholdParams") {
-        stepPod = contentManager.getPod("ConfigureFailureThresholdParams", 0).accessPodContent();
-        breadcrumbElement = stepPod.find('.failureThresholdSteps > .stepProgression > .tabContainer-tabs > .nav-tabs');
-        activeStep = breadcrumbElement.find('li.active');
-        activeStep.next().find('a').click();
       } else if (stepName === "ConfigureDelayParams") {
-        stepPod = contentManager.getPod("ConfigureDelayParams", 0).accessPodContent();
-        breadcrumbElement = stepPod.find('.delaySteps > .stepProgression > .tabContainer-tabs > .nav-tabs');
-        activeStep = breadcrumbElement.find('li.active');
-        activeStep.next().find('a').click();
       } else if (stepName === "ConfigureSuccessThresholdParams") {
-        stepPod = contentManager.getPod("ConfigureSuccessThresholdParams", 0).accessPodContent();
-        breadcrumbElement = stepPod.find('.successThresholdSteps > .stepProgression > .tabContainer-tabs > .nav-tabs');
-        activeStep = breadcrumbElement.find('li.active');
-        activeStep.next().find('a').click();
       }
     };
 

--- a/json-guides/circuit-breaker.json
+++ b/json-guides/circuit-breaker.json
@@ -46,39 +46,30 @@
           "title": "Example: Bank Scenario",
           "description": [
             "Imagine that your online banking application has many different microservices:",
-            "<ul><li>A service for checking your balance<li>A service for transferring money<li>A service for depositing money<li>A balance snapshot service that is used as a backup of data</ul>In the next step, you will try to check your balance on the bank's website.",
-            "<div class='bankScenarioImg'><img src='/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/images/intro.svg' alt='Online Banking Microservices'></div>"
+            "<ul><li>A service for checking your balance<li>A service for transferring money<li>A service for depositing money<li>A balance snapshot service that is used as a backup of data</ul>",
+            "<div class='bankScenarioImg'><img src='/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/images/intro.svg' alt='Online Banking Microservices'></div>",
+            "Visit your bank's website to check your current balance."          ],
+          "instruction": [
+            "Enter the following URL into the browser that follows, or click <action title='URL' onclick=\"circuitBreakerCallBack.populate_url(event, 'BankScenario')\">https://global-ebank.openliberty.io/checkBalance</action> and then press <action title='Enter' onclick=\"circuitBreakerCallBack.enterButtonURLCheckBalance(event, 'BankScenario')\">Enter</action>."
           ],
-          "sections": [
+          "content":[
             {
-              "name": "CheckBalance",
-              "title": "Checking your balance",
-              "description": [
-                "Visit your bank's website to check your current balance."
-              ],
-              "instruction": [
-                "Enter the following URL into the browser that follows, or click <action title='URL' onclick=\"circuitBreakerCallBack.populate_url(event, 'CheckBalance')\">https://global-ebank.openliberty.io/checkBalance</action> and then press <action title='Enter' onclick=\"circuitBreakerCallBack.enterButtonURLCheckBalance(event, 'CheckBalance')\">Enter</action>."
-              ],
-              "content":[
+              "displayType":"webBrowser",
+              "url": "",
+              "browserContent": "",
+              "callback": "(function test(webBrowser) {circuitBreakerCallBack.listenToBrowserForFailBalance(webBrowser); })"
+            },
+            {
+              "displayType":"pod"
+            },
+            {
+              "displayType": "tabbedEditor",
+              "enable": false,
+              "editorList": [
                 {
-                  "displayType":"webBrowser",
-                  "url": "",
-                  "browserContent": "",
-                  "callback": "(function test(webBrowser) {circuitBreakerCallBack.listenToBrowserForFailBalance(webBrowser); })"
-                },
-                {
-                  "displayType":"pod"
-                },
-                {
-                  "displayType": "tabbedEditor",
-                  "enable": false,
-                  "editorList": [
-                    {
-                        "displayType": "fileEditor",
-                        "fileName": " ",
-                        "save": true
-                    }
-                  ]
+                    "displayType": "fileEditor",
+                    "fileName": " ",
+                    "save": true
                 }
               ]
             }
@@ -150,8 +141,8 @@
                 "enable": false
             },
             {
-                "displayType":"pod",
-                "content": "<img src='/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/images/blank-circuit.svg' alt='Check Balance microservice' class='picInPod'>"
+            "displayType":"pod",
+            "content": "<div class='centerPicInPod'><img src='/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/images/blank-circuit.svg' alt='Check Balance microservice' class='picInPod'></div>"
             },
             {
                 "displayType": "tabbedEditor",
@@ -224,11 +215,60 @@
           "content":
           [
             {
-                "displayType": "webBrowser"
+                "displayType": "webBrowser",
+                "url": "https://global-ebank.openliberty.io/checkBalance",
+                "browserContent": "/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/check-balance-fail-with-open-circuit.html",
+                "callback": "(function test(webBrowser) {circuitBreakerCallBack.listenToBrowserForFailBalance(webBrowser); })"
             },
             {
                 "displayType": "pod",
-                "content": "/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/configure-failure-threshold-tabs.html"
+                "content": "<div class='centerPicInPod'><img src='/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/images/with-circuit-breaker.svg' alt='Check Balance microservice with circuit breaker' class='picInPod'></div>"
+            },
+            {
+                "displayType": "tabbedEditor",
+                "editorList": [
+                    {
+                        "displayType": "fileEditor",
+                        "fileName": "BankService.java",
+                        "preload": [
+                            "package io.openliberty.guides.circuitbreaker.global.eBank.microservices;",
+                            "",
+                            "import javax.enterprise.context.ApplicationScoped;",
+                            "",
+                            "import org.eclipse.microprofile.faulttolerance.CircuitBreaker;",
+                            "import org.eclipse.microprofile.faulttolerance.Fallback;",
+                            "",
+                            "import io.openliberty.guides.circuitbreaker.global.eBank.exceptions.ConnectException;",
+                            "",
+                            "@ApplicationScoped",
+                            "public class BankService {",
+                            "",
+                            "    @CircuitBreaker()",
+                            "    public Service checkBalance() {",
+                            "        counterForInvokingBankingService++;",
+                            "        return checkBalanceService();",
+                            "    }",
+                            "}"
+                        ],
+                        "readonly": [
+                            {
+                                "from": "1",
+                                "to": "12"
+                            },
+                            {
+                                "from": "14",
+                                "to": "18"
+                            }
+                        ],
+                        "writable": [
+                            {
+                                "line": "13"
+                            }
+                        ],
+                        "save": false,
+                        "callback": "(function test(editor) {circuitBreakerCallBack.listenToEditorForAnnotationParamChange(editor); })"
+                    }
+                ]
             }
           ]
         },


### PR DESCRIPTION
**checkBalance.css**
- Adjusted the font size for the new design

**circuitBreaker.css** --> rename to **circuitBreaker.scss**
- Adjusted the css for the pods in the guide that show just a picture or show text with a picture.  Hopefully the text and picture will be side-by-side in multi-column view, and text above the picture in single column view.

**circuit-Breaker.json**
- Collapsed the **Check your balance** step into the **Example: bank scenario** because the step just was not vertically tall enough to correctly view the widgets while scrolling and was not necessary to the guide to be called out as a separate step.
- Work on the "ConfigureFailureThresholdParams" step to pull the widgets out of the 3-tabbed pod defined in **circuit-breaker-configure-failure-threshold.html** as seen in the previous version of this guide to having the widgets display on the right side of the multi-column view.

**circuit-breaker-callback.js**
- Updates to the callback to handle the changes made in **circuit-Breaker.json**...namely getting rid of the **Check your balance** step and pulling the logic for the **ConfigureFailureThresholdParams** step from **circuit-breaker-configure-failure-threshold.html** into this file.   In the future I will be deleting **circuit-breaker-configure-failure-threshold.html**.

**NOTE:**  the **Configure it** instruction is still not working for the **ConfigureFailureThresholdParams** step.