### PR TITLE
Focus proper widget for each instruction in config steps

### DIFF
--- a/js/interactive-guides/circuit-breaker/circuit-breaker-callback.js
+++ b/js/interactive-guides/circuit-breaker/circuit-breaker-callback.js
@@ -51,7 +51,7 @@ var circuitBreakerCallBack = (function() {
                         break;
                     case 'ConfigureDelayParams':
                             // Put the browser into focus.
-                            webBrowser.contentRootElement.click();
+                            webBrowser.contentRootElement.trigger("click");
 
                             clearInterval(delayCountdownInterval);
                              __refreshWebBrowserContent(webBrowser, "/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/check-balance-fail-with-open-circuit.html");
@@ -87,12 +87,10 @@ var circuitBreakerCallBack = (function() {
                         break;
                     case 'ConfigureFailureThresholdParams':
                         // Put the browser into focus.
-                        webBrowser.contentRootElement.click();
+                        webBrowser.contentRootElement.trigger("click");
 
                         var currentStepIndex = contentManager.getCurrentInstructionIndex(stepName);
                         if (currentStepIndex === 1) {
-                            var stepWidgets = stepContent.getStepWidgets(stepName);
-                            stepContent.resizeStepWidgets(stepWidgets, "webBrowser", true);
                            __refreshWebBrowserContent(webBrowser, "/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/check-balance-fail.html");
                            webBrowser.enableRefreshButton(false);
                            isRefreshing = true;
@@ -140,7 +138,7 @@ var circuitBreakerCallBack = (function() {
     var __listenToBrowserFromHalfOpenCircuit = function (webBrowser) {
         var setBrowserContent = function (currentURL) {
             // Put the browser into focus.
-            webBrowser.contentRootElement.click();
+            webBrowser.contentRootElement.trigger("click");
 
             if (currentURL.trim() === checkBalanceURL) {
 
@@ -259,7 +257,7 @@ var circuitBreakerCallBack = (function() {
 //                contentManager.markTabbedEditorReadOnly(stepName, "BankService.java");
                 // Put the browser into focus.
                 var stepBrowser = contentManager.getBrowser(stepName);
-                stepBrowser.contentRootElement.click();
+                stepBrowser.contentRootElement.trigger("click");
                 
                 contentManager.markCurrentInstructionComplete(stepName);
             } else {

--- a/js/interactive-guides/circuit-breaker/circuit-breaker-callback.js
+++ b/js/interactive-guides/circuit-breaker/circuit-breaker-callback.js
@@ -50,6 +50,9 @@ var circuitBreakerCallBack = (function() {
 
                         break;
                     case 'ConfigureDelayParams':
+                            // Put the browser into focus.
+                            webBrowser.contentRootElement.click();
+
                             clearInterval(delayCountdownInterval);
                              __refreshWebBrowserContent(webBrowser, "/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/check-balance-fail-with-open-circuit.html");
                             contentManager.setPodContentWithRightSlide(stepName,
@@ -83,6 +86,9 @@ var circuitBreakerCallBack = (function() {
                             }, 100);
                         break;
                     case 'ConfigureFailureThresholdParams':
+                        // Put the browser into focus.
+                        webBrowser.contentRootElement.click();
+
                         var currentStepIndex = contentManager.getCurrentInstructionIndex(stepName);
                         if (currentStepIndex === 1) {
                             var stepWidgets = stepContent.getStepWidgets(stepName);
@@ -133,6 +139,9 @@ var circuitBreakerCallBack = (function() {
 
     var __listenToBrowserFromHalfOpenCircuit = function (webBrowser) {
         var setBrowserContent = function (currentURL) {
+            // Put the browser into focus.
+            webBrowser.contentRootElement.click();
+
             if (currentURL.trim() === checkBalanceURL) {
 
                 var stepName = this.getStepName();
@@ -250,6 +259,7 @@ var circuitBreakerCallBack = (function() {
 //                contentManager.markTabbedEditorReadOnly(stepName, "BankService.java");
                 // Put the browser into focus.
                 var stepBrowser = contentManager.getBrowser(stepName);
+                stepBrowser.contentRootElement.click();
                 
                 contentManager.markCurrentInstructionComplete(stepName);
             } else {
@@ -720,6 +730,8 @@ var circuitBreakerCallBack = (function() {
           __listenToEditorForCircuitBreakerAnnotationChanges(editor);
       }
 
+      // Put the tabbedEditor into focus with  "BankService.java" file selected.
+      contentManager.focusTabbedEditorByName(stepName, "BankService.java");
     };
 
     //The 'Configure it' button to bring up a playground for each configure step.
@@ -839,6 +851,8 @@ var circuitBreakerCallBack = (function() {
             cb.closeCircuit();
         });
         contentManager.setPlayground(stepName, cb, 0);
+
+        root.find('.circuitBreakerSuccessRequest').focus();
     };
 
     var __listenToEditorForFeatureInServerXML = function(editor) {

--- a/json-guides/circuit-breaker.json
+++ b/json-guides/circuit-breaker.json
@@ -381,6 +381,7 @@
             },
             {
                 "displayType": "tabbedEditor",
+                "active": true,
                 "editorList": [
                     {
                         "displayType": "fileEditor",
@@ -459,6 +460,7 @@
             },
             {
                 "displayType": "tabbedEditor",
+                "active": true,
                 "editorList": [
                     {
                         "displayType": "fileEditor",
@@ -654,6 +656,7 @@
                 "editorList": [
                     {
                         "displayType":"fileEditor",
+                        "active": true,
                         "fileName": "BankService.java",
                         "preload": [
                             "package io.openliberty.guides.circuitbreaker.global.eBank.microservices;",

--- a/json-guides/circuit-breaker.json
+++ b/json-guides/circuit-breaker.json
@@ -653,10 +653,10 @@
             },
             {
                 "displayType": "tabbedEditor",
+                "active": true,
                 "editorList": [
                     {
                         "displayType":"fileEditor",
-                        "active": true,
                         "fileName": "BankService.java",
                         "preload": [
                             "package io.openliberty.guides.circuitbreaker.global.eBank.microservices;",


### PR DESCRIPTION
In the config steps, ensure the editor is the first widget focused.

Following the successful edit (1st instruction), put focus on the browser widget until all refreshes are complete.

When 'Configure it' is selected, move focus back to the editor so it is fully expanded and the user can update the values within.

I also added focus to the editor in the playground step so that it is expanded when you enter the step.