### PR TITLE
Change the editor on the CB playground step to have 'Run'

### DIFF
--- a/json-guides/circuit-breaker.json
+++ b/json-guides/circuit-breaker.json
@@ -849,7 +849,7 @@
                                 "line": "16"
                             }
                         ],
-                        "save": true,
+                        "save": false,
                         "callback": "(function test(editor) {circuitBreakerCallBack.listenToEditorForCircuitBreakerAnnotationChanges(editor); })"
                     }
                 ]


### PR DESCRIPTION
Change the editor on the actual CB guide playground step to have 'Run' instead of 'Save' to match what is on the editors of the other playgrounds.