### PR TITLE
Highlight the delay countdown in the Delay step

### DIFF
--- a/css/interactive-guides/circuit-breaker/circuit-breaker.scss
+++ b/css/interactive-guides/circuit-breaker/circuit-breaker.scss
@@ -235,12 +235,17 @@
   white-space: nowrap;
 
   @media (min-width: 1170px) {
-    margin: 15px;
-    display: inline;
+    margin: 5px 15px;
+    display: inline-block;
+    width: 100px;
   }
   @media (max-width: 1169px) {
     margin-bottom: 10px;
   }
+}
+
+.delayCountdownColor {
+  color: red;
 }
 
 .delayStateChangeText {
@@ -251,6 +256,14 @@
     margin-left: 100px;
     display: inline;
   }
+}
+
+.openState {
+  color: #e62325;
+}
+
+.halfOpenState {
+  color: #E3700D;
 }
 
 .playgroundImg {

--- a/js/interactive-guides/circuit-breaker/circuit-breaker-callback.js
+++ b/js/interactive-guides/circuit-breaker/circuit-breaker-callback.js
@@ -59,8 +59,8 @@ var circuitBreakerCallBack = (function() {
                                 "<div class='flexWithPic'>" +
                                 "<div class='leftDelayPodText'><p>Assuming the circuit is in an <b>open</b> state, the request to the Check Balance microservice fails immediately.  You are instantly notified of the problem and no longer must wait for the time-out period to occur to receive the notification.</p>" +
                                 "<p style='padding-top: 0;'>The circuit remains in an open state for <code>5000 ms</code> before switching to a <b>half-open</b> state.</p>" +
-                                "<div class='delayCountdownText'><b>Delay:&nbsp;&nbsp;</b><span class='delayCountdown'>5000 ms</span></div>" +
-                                "<div class='delayStateChangeText'><b>Circuit State:&nbsp;&nbsp;</b><span class='delayState'> Open</span></div>" +
+                                "<div class='delayCountdownText'><b>Delay:&nbsp;&nbsp;</b><span class='delayCountdown delayCountdownColor'>5000 ms</span></div>" +
+                                "<div class='delayStateChangeText'><b>Circuit State:&nbsp;&nbsp;</b><span class='delayState openState'> Open</span></div>" +
                                 "</div>" +
                                 "<div class='delayCountdownImgDiv'><div class='pod-animation-slide-from-right'><img src='/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/images/open.svg' alt='Check Balance microservice in open circuit' class='picInPod playgroundImg'></div></div>" +
                                 "</div>",
@@ -75,7 +75,8 @@ var circuitBreakerCallBack = (function() {
                                     $delayCountdown.text(secondsLeft + " ms");
                                 }
                                 if (secondsLeft <= 0) {
-                                    $('.delayState').text("Half-Open");
+                                    $('.delayCountdown').removeClass("delayCountdownColor");
+                                    $('.delayState').removeClass("openState").addClass("halfOpenState").text("Half-Open");
 
                                     clearInterval(delayCountdownInterval);   // Stop interval
                                     // Slide in new pic


### PR DESCRIPTION
Style the delay countdown and state text on the Configuring a Delay step so that it draws the user's attention to the countdown.

The countdown numbers will be red until they hit 0ms.
The countdown state will be red initially for an Open state, then switch to orange to represent a half-open state.