### PR TITLE
Alt tag for image on FailureThreshold step is incorrect.

### DIFF
--- a/js/interactive-guides/circuit-breaker/cb-messages.js
+++ b/js/interactive-guides/circuit-breaker/cb-messages.js
@@ -43,6 +43,7 @@ var circuitBreakerMessages = (function() {
             CHECK_BALANCE_CLOSED: circuit_breaker_messages.CHECK_BALANCE_CLOSED,
             CHECK_BALANCE_HALF_OPEN: circuit_breaker_messages.CHECK_BALANCE_HALF_OPEN,
             CHECK_BALANCE_RESULT_OPEN: circuit_breaker_messages.CHECK_BALANCE_RESULT_OPEN,
+            CHECK_BALANCE_RESULT_CLOSED: circuit_breaker_messages.CHECK_BALANCE_RESULT_CLOSED,
             CHECK_BALANCE_RESULT_HALF_OPEN: circuit_breaker_messages.CHECK_BALANCE_RESULT_HALF_OPEN
         };
     };

--- a/js/interactive-guides/circuit-breaker/circuit-breaker-callback.js
+++ b/js/interactive-guides/circuit-breaker/circuit-breaker-callback.js
@@ -116,7 +116,7 @@
                            setTimeout(function () {
                                 contentManager.setPodContentWithRightSlide(webBrowser.getStepName(),
                                     "<div class='flexWithPic'>" +
-                                    "<img src='/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/images/closed_serviceFailed.svg' alt='" + cbmessages.CHECK_BALANCE_RESULT_OPEN + "' class='picInPod'>" +
+                                    "<img src='/guides/iguide-circuit-breaker/html/interactive-guides/circuit-breaker/images/closed_serviceFailed.svg' alt='" + cbmessages.CHECK_BALANCE_RESULT_CLOSED + "' class='picInPod'>" +
                                     "<p>" + cbmessages.THRESHOLD_1 + "</p>" +
                                     "</div>",
                                     0

--- a/js/interactive-guides/circuit-breaker/nls/messages.js
+++ b/js/interactive-guides/circuit-breaker/nls/messages.js
@@ -49,7 +49,8 @@ var circuit_breaker_messages = {
     CHECK_BALANCE_OPEN: "Check Balance microservice in open circuit",
     CHECK_BALANCE_CLOSED: "Check Balance microservice in closed circuit",
     CHECK_BALANCE_HALF_OPEN: "Check Balance microservice in half open circuit",
-    CHECK_BALANCE_RESULT_OPEN: "Check Balance microservice resulting in open circuit",
+    CHECK_BALANCE_RESULT_OPEN: "Check Balance microservice fails resulting in open circuit",
+    CHECK_BALANCE_RESULT_CLOSED: "Check Balance microservice fails but remains closed until requestVolumeThreshold is met",
     CHECK_BALANCE_RESULT_HALF_OPEN: "Check Balance microservice in half open circuit"
   } ;
  


### PR DESCRIPTION
The alt tag for the closed_serviceFailed.svg, which is displayed only on the Failure Threshold step as the image shown following the first time the user selects Refresh (The one in the pod that slides in), was not correct. Created a new message to accurately reflect the image.