### PR TITLE
Only bold button names not in an action of an instruction

### DIFF
--- a/json-guides/circuit-breaker.json
+++ b/json-guides/circuit-breaker.json
@@ -276,7 +276,7 @@
             "Change the <code>@CircuitBreaker</code> annotation on line 13 to the following code, or click <br><action title='Circuit breaker annotation with failure threshold parameters' onclick=\"circuitBreakerCallBack.addCircuitBreakerAnnotationButton(event, 'ConfigureFailureThresholdParams')\">@CircuitBreaker\n(requestVolumeThreshold=2, failureRatio=0.5)</action>.<br>Then, click <action title='Run' onclick=\"circuitBreakerCallBack.saveButtonEditorButton(event, 'ConfigureFailureThresholdParams')\">Run</action> on the editor menu pane.",
             "Click <action title='Refresh' onclick=\"circuitBreakerCallBack.refreshButtonBrowser(event, 'ConfigureFailureThresholdParams')\">Refresh</action> in the browser to see the first Check Balance call fail in the closed circuit state.",
             "Click <action title='Refresh' onclick=\"circuitBreakerCallBack.refreshButtonBrowser(event, 'ConfigureFailureThresholdParams')\">Refresh</action> again in the browser to see the second call fail which changes the circuit to the open state.",
-            "Click <action title='Configure failure threshold parameters' onclick=\"circuitBreakerCallBack.configureItButton(event, 'ConfigureFailureThresholdParams')\">Configure it</action> to simulate successful or failed requests to the microservice. <br>You can <b>modify</b> the <code>@CircuitBreaker</code> annotation parameters in the editor to configure your circuit breaker, then click <b>Run</b> in the editor to see how the circuit state changes."
+            "Click <action title='Configure failure threshold parameters' onclick=\"circuitBreakerCallBack.configureItButton(event, 'ConfigureFailureThresholdParams')\">Configure it</action> to simulate successful or failed requests to the microservice. <br>You can modify the <code>@CircuitBreaker</code> annotation parameters in the editor to configure your circuit breaker, then click <b>Run</b> in the editor to see how the circuit state changes."
           ],
           "content":
           [
@@ -366,7 +366,7 @@
           "instruction": [
               "Change the <code>@CircuitBreaker</code> annotation on lines 13 and 14 to the following code, or click <br><action title='Circuit breaker annotation with delay parameter' onclick=\"circuitBreakerCallBack.addCircuitBreakerAnnotationButton(event, 'ConfigureDelayParams')\">@CircuitBreaker\n(requestVolumeThreshold=2, failureRatio=0.5, delay=5000)</action>.<br> Then, click <action title='Run' onclick=\"circuitBreakerCallBack.saveButtonEditorButton(event, 'ConfigureDelayParams')\">Run</action>.",
               "Click <action title='Refresh' onclick=\"circuitBreakerCallBack.refreshButtonBrowser(event, 'ConfigureDelayParams')\">Refresh</action> in the browser to see how the annotation affects the Check Balance call.",
-              "Click <action title='Configure delay parameters' onclick=\"circuitBreakerCallBack.configureItButton(event, 'ConfigureDelayParams')\">Configure it</action> to simulate successful or failed requests to the microservice. <br>You can <b>modify</b> the <code>@CircuitBreaker</code> annotation parameters in the editor to configure your circuit breaker, then click <b>Run</b> in the editor to see how the circuit state changes."
+              "Click <action title='Configure delay parameters' onclick=\"circuitBreakerCallBack.configureItButton(event, 'ConfigureDelayParams')\">Configure it</action> to simulate successful or failed requests to the microservice. <br>You can modify the <code>@CircuitBreaker</code> annotation parameters in the editor to configure your circuit breaker, then click <b>Run</b> in the editor to see how the circuit state changes."
           ],
           "content": [
             {
@@ -461,7 +461,7 @@
               "Change the <code>@CircuitBreaker</code> annotation on lines 13 - 15 to the following code, or click<action title='Circuit breaker annotation with success threshold parameter' aria-label='Circuit breaker annotation with success threshold parameter' onclick=\"circuitBreakerCallBack.addCircuitBreakerAnnotationButton(event, 'ConfigureSuccessThresholdParams')\">@CircuitBreaker\n(requestVolumeThreshold=2, failureRatio=0.5, delay=5000, successThreshold=2)</action>.<br> Then, click <action title='Run' aria-label='Run' onclick=\"circuitBreakerCallBack.saveButtonEditorButton(event, 'ConfigureSuccessThresholdParams')\">Run</action>.",
               "Click <action title='Refresh' onclick=\"circuitBreakerCallBack.refreshButtonBrowser(event, 'ConfigureSuccessThresholdParams')\">Refresh</action> in the browser to see the first Check Balance call succeed in the half-open circuit state.<br>",
               "Click <action title='Refresh' onclick=\"circuitBreakerCallBack.refreshButtonBrowser(event, 'ConfigureSuccessThresholdParams')\"><b>Refresh</b></action> in the browser again. This second successful call meets our success threshold parameter value and closes the circuit.",
-              "Click <action title='Configure success threshold parameters' onclick=\"circuitBreakerCallBack.configureItButton(event, 'ConfigureSuccessThresholdParams')\">Configure it</action> to simulate successful or failed requests to the microservice. <br>You can <b>modify</b> the <code>@CircuitBreaker</code> annotation parameters in the editor to configure your circuit breaker, then click <b>Run</b> in the editor to see how the circuit state changes."
+              "Click <action title='Configure success threshold parameters' onclick=\"circuitBreakerCallBack.configureItButton(event, 'ConfigureSuccessThresholdParams')\">Configure it</action> to simulate successful or failed requests to the microservice. <br>You can modify the <code>@CircuitBreaker</code> annotation parameters in the editor to configure your circuit breaker, then click <b>Run</b> in the editor to see how the circuit state changes."
           ],
           "content":[
             {
@@ -728,7 +728,7 @@
               "You can simulate successful or failed requests to the microservice to see how the circuit state changes."
             ],
             "instruction": [
-              "Modify the parameters for the <code>@CircuitBreaker</code> annotation in the editor, then click Run to see how the circuit state changes. Repeat the process as many times as you like. <br><br>Click Success for successful requests or Failure for failed requests and observe the simulation."
+              "Modify the parameters for the <code>@CircuitBreaker</code> annotation in the editor, then click <b>Run</b> to see how the circuit state changes. Repeat the process as many times as you like. <br><br>Click <b>Success</b> for successful requests or <b>Failure</b> for failed requests and observe the simulation."
             ],
             "content":[
             {


### PR DESCRIPTION
Removed bolding around the word 'Modify' in the 'Configure it' instructions.

Added bolding around 'Success' and 'Failure' in the playground instructions.